### PR TITLE
Fixing KeyError in admin

### DIFF
--- a/emails/admin.py
+++ b/emails/admin.py
@@ -190,7 +190,8 @@ class EmailAdminForm(forms.ModelForm):
 
         # Overriding the CKEditor widget for the `content` field; this allows us
         # to use custom placeholders for different email types.
-        self.fields["content"].widget = CKEditorWidget(config_name="email_editor")
+        if "content" in self.fields:
+            self.fields["content"].widget = CKEditorWidget(config_name="email_editor")
 
     def clean_content(self):
         """Validate that only specific placeholders are used in "normal" emails."""
@@ -503,7 +504,10 @@ class InvitationEmailForm(forms.ModelForm):
 
         # Overriding the CKEditor widget for the `content` field; this allows us
         # to use custom placeholders for different email types.
-        self.fields["content"].widget = CKEditorWidget(config_name="invitation_editor")
+        if "content" in self.fields:
+            self.fields["content"].widget = CKEditorWidget(
+                config_name="invitation_editor"
+            )
 
     def clean(self):
         cleaned_data = super().clean()


### PR DESCRIPTION
When viewing existing emails, `self.fields == {}` in the form `__init__`, because the `change` view is actually read-only.

Checking that the field actually exists in `self.fields` before overriding its widget.