### PR TITLE
Fix timezone related warnings in tests; refs #30626

### DIFF
--- a/api/tests/factories.py
+++ b/api/tests/factories.py
@@ -70,9 +70,9 @@ class EventFactory(factory.django.DjangoModelFactory):
 
     code = factory.Sequence(lambda n: f"EVT{n:03}")
     title = factory.Sequence(lambda n: f"Test Event {n}")
-    start_date = factory.LazyFunction(lambda: timezone.now().date())
+    start_date = factory.LazyFunction(lambda: timezone.now())
     end_date = factory.LazyFunction(
-        lambda: (timezone.now() + timezone.timedelta(days=3)).date()
+        lambda: (timezone.now() + timezone.timedelta(days=3))
     )
     venue_city = "Test City"
     venue_country = factory.SubFactory(CountryFactory)

--- a/api/tests/test_events.py
+++ b/api/tests/test_events.py
@@ -215,13 +215,13 @@ class TestEventNominationsAPI(BaseAPITestCase):
             event=self.event,
             contact=self.contact1,
             status_id=get_nomination_status_id(),
-            date=timezone.now().date(),
+            date=timezone.now(),
         )
         RegistrationFactory(
             event=self.event,
             contact=self.contact2,
             status_id=get_nomination_status_id(),
-            date=timezone.now().date(),
+            date=timezone.now(),
         )
 
         response = self.client.get(self.url)

--- a/api/views/event.py
+++ b/api/views/event.py
@@ -119,7 +119,7 @@ class EventNominationViewSet(ViewSet):
                     role=nomination["role"],
                     is_funded=nomination["is_funded"],
                     priority_pass_code=nomination.get("priority_pass_code", ""),
-                    date=timezone.now().date(),
+                    date=timezone.now(),
                 )
             registrations.append(registration)
 

--- a/emails/tests/test_admin.py
+++ b/emails/tests/test_admin.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime
+
 from django.conf import settings
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth import get_user_model

--- a/emails/tests/test_admin.py
+++ b/emails/tests/test_admin.py
@@ -1,3 +1,4 @@
+from datetime import UTC, datetime
 from django.conf import settings
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth import get_user_model
@@ -44,8 +45,8 @@ class TestInvitationEmailAdmin(TestCase):
         self.event = Event.objects.create(
             code="TEST01",
             title="Test Event",
-            start_date="2025-01-01",
-            end_date="2025-01-02",
+            start_date=datetime(2025, 1, 1, tzinfo=UTC),
+            end_date=datetime(2025, 1, 2, tzinfo=UTC),
             venue_country=Country.objects.first(),
         )
 
@@ -455,8 +456,8 @@ class TestInvitationEmailAdminGovBehaviour(TestCase):
         self.event = Event.objects.create(
             code="TEST01",
             title="Test Event",
-            start_date="2025-01-01",
-            end_date="2025-01-02",
+            start_date=datetime(2025, 1, 1, tzinfo=UTC),
+            end_date=datetime(2025, 1, 2, tzinfo=UTC),
             venue_country=Country.objects.first(),
         )
 


### PR DESCRIPTION
Related to https://helpdesk.eaudeweb.ro/issues/30626.

The warnings came from saving naive date on `DateTimeField`. Ref from [Django docs](https://docs.djangoproject.com/en/5.2/topics/i18n/timezones/#time-zones-migration-guide:~:text=When%20USE_TZ%20is%20True%2C%20Django%20still%20accepts%20naive%20datetime%20objects%2C%20in%20order%20to%20preserve%20backwards%2Dcompatibility.%20When%20the%20database%20layer%20receives%20one%2C%20it%20attempts%20to%20make%20it%20aware%20by%20interpreting%20it%20in%20the%20default%20time%20zone%20and%20raises%20a%20warning.)