### PR TITLE
Don't allow changes to registrations that have non-default status

### DIFF
--- a/api/views/event.py
+++ b/api/views/event.py
@@ -24,6 +24,7 @@ from events.models import (
     EventInvitation,
     Registration,
     RegistrationRole,
+    get_default_status,
 )
 
 
@@ -48,7 +49,10 @@ class EventNominationViewSet(ViewSet):
     lookup_field = "token"
 
     def get_invitation(self, token) -> EventInvitation:
-        return get_object_or_404(EventInvitation, token=token)
+        invitation = get_object_or_404(EventInvitation, token=token)
+        invitation.link_accessed = True
+        invitation.save()
+        return invitation
 
     def get_queryset(self):
         # Get the invitation using the token from the URL
@@ -151,6 +155,7 @@ class EventNominationViewSet(ViewSet):
         current_nominations = {
             n.event: n for n in contact.registrations.filter(event__in=available_events)
         }
+        default_status = get_default_status()
 
         with transaction.atomic():
             for nomination in serializer.validated_data:
@@ -169,12 +174,20 @@ class EventNominationViewSet(ViewSet):
                 except KeyError:
                     registration = Registration(event=event, contact=contact)
 
+                if (
+                    registration.status != default_status
+                    and registration.role != nomination["role"]
+                ):
+                    raise ValidationError({"status": "Registration cannot be updated."})
+
                 registration.role = nomination["role"]
                 registration.save()
 
             # Anything left of the current nominations that was not provided
             # needs to be removed.
             for registration in current_nominations.values():
+                if registration.status != default_status:
+                    raise ValidationError({"status": "Registration cannot be removed."})
                 registration.delete()
 
         return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
- Once a registration moves past the nomintated status, don't allow further changes via the token auth view and api.
- Add current status of nominations to the view 
- Update the link_accessed flag for invitations
