### PR TITLE
Priority pass visual adjustments, refs #31355

### DIFF
--- a/templates/admin/events/prioritypass/priority_pass.html
+++ b/templates/admin/events/prioritypass/priority_pass.html
@@ -119,6 +119,24 @@
         margin: 0 0 8px 0;
       }
 
+      .details dl {
+        margin: 0;
+      }
+
+      .details dt:first-child {
+        margin-top: 0;
+      }
+
+      .details dt {
+        margin-top: 8px;
+        margin-bottom: 2px;
+        font-weight: bold;
+      }
+
+      .details dd {
+        margin: 0 0 4px 0;
+      }
+
       footer {
         position: absolute;
         bottom: 0;

--- a/templates/admin/events/prioritypass/priority_pass.html
+++ b/templates/admin/events/prioritypass/priority_pass.html
@@ -90,7 +90,7 @@
 
       tbody tr td {
         background-color: #62a6d2;
-        font-size: 22px;
+        font-size: 18px;
         font-weight: bold;
       }
 
@@ -102,7 +102,7 @@
       }
 
       .name {
-        font-size: 24px;
+        font-size: 18px;
         font-weight: bold;
       }
 

--- a/templates/admin/events/prioritypass/priority_pass.html
+++ b/templates/admin/events/prioritypass/priority_pass.html
@@ -107,7 +107,7 @@
       }
 
       .details {
-        margin-top: 24px;
+        margin-top: 2em;
         display: grid;
         grid-template-columns: 1fr 1fr;
         gap: 16px;

--- a/templates/admin/events/prioritypass/priority_pass.html
+++ b/templates/admin/events/prioritypass/priority_pass.html
@@ -107,11 +107,16 @@
       }
 
       .details {
+        margin-top: 24px;
         display: grid;
         grid-template-columns: 1fr 1fr;
         gap: 16px;
         align-items: start;
         justify-content: space-between;
+      }
+
+      .details p {
+        margin: 0 0 8px 0;
       }
 
       footer {

--- a/templates/admin/events/prioritypass/priority_pass.html
+++ b/templates/admin/events/prioritypass/priority_pass.html
@@ -124,6 +124,7 @@
         margin: 0 0 8px 0;
       }
 
+      /* The below two rules ensure 'phone' is properly aligned vertically */
       .details dl {
         margin: 0;
       }

--- a/templates/admin/events/prioritypass/priority_pass.html
+++ b/templates/admin/events/prioritypass/priority_pass.html
@@ -124,25 +124,6 @@
         margin: 0 0 8px 0;
       }
 
-      /* The below two rules ensure 'phone' is properly aligned vertically */
-      .details dl {
-        margin: 0;
-      }
-
-      .details dt:first-child {
-        margin-top: 0;
-      }
-
-      .details dt {
-        margin-top: 8px;
-        margin-bottom: 2px;
-        font-weight: bold;
-      }
-
-      .details dd {
-        margin: 0 0 4px 0;
-      }
-
       footer {
         position: absolute;
         bottom: 0;
@@ -204,24 +185,17 @@
           {{ organization.country.name|default:'-' }}
         </p>
       </div>
-      <dl>
-        <dt>Phone</dt>
-        <dd>{{ contact.phones|join:", "|default:"-" }}</dd>
-        <dt>Email</dt>
-        <dd>{{ contact.emails|join:", "|default:"-" }}</dd>
-        <dt>Other emails</dt>
-        <dd>{{ contact.email_ccs|join:", "|default:"-" }}</dd>
-      </dl>
     </section>
     <footer>
       <p><b>Note</b></p>
       <p>
-        This Priority Pass bears the information needed to obtain your conference badge. Please bring a copy of this
-        Priority Pass on-site and have your PASSPORT ready for verification.
+        This pass bears the information required for you to obtain your meeting badge. A copy of this pass, either
+        printed or on a handheld device, must be presented, along with a valid photo identification card, to pick up
+        your badge at the registration counter.
       </p>
-      <p>This is only valid for the person whose name is mentioned on this pass. This pass is non-transferable.</p>
+      <p>This pass is only valid for the person whose name is mentioned on it. This pass is not transferable.</p>
       <p class="warning">
-        !! THIS PASS DOES NOT GRANT ACCESS TO THE VENUE. IT CAN SOLELY BE USED TO OBTAIN AN ACCESS BADGE !!
+        !! THIS PASS DOES NOT GRANT ACCESS TO THE VENUE. IT CAN ONLY BE USED TO OBTAIN A MEETING BADGE !!
       </p>
     </footer>
   </body>

--- a/templates/admin/events/prioritypass/priority_pass.html
+++ b/templates/admin/events/prioritypass/priority_pass.html
@@ -94,6 +94,11 @@
         font-weight: bold;
       }
 
+      .event-title {
+        font-size: 14px;
+        padding-bottom: 8px;
+      }
+
       .country {
         margin-top: 24px;
         text-transform: uppercase;
@@ -176,7 +181,7 @@
             <td>{{ registration.event.dates }}</td>
           </tr>
           <tr>
-            <td colspan="3">{{ registration.event.title }}</td>
+            <td class="event-title" colspan="3">{{ registration.event.title }}</td>
           </tr>
         </tbody>
       {% endfor %}


### PR DESCRIPTION
This is how it looks now with an extremely long venue name:
<img width="788" height="497" alt="Screenshot 2025-07-23 at 17 17 24" src="https://github.com/user-attachments/assets/9361f3c9-c345-4db8-bb69-5d1c06b354df" />
