### PR TITLE
Hide print badge if not registered

### DIFF
--- a/api/serializers/contact.py
+++ b/api/serializers/contact.py
@@ -120,7 +120,8 @@ class ContactSerializer(serializers.ModelSerializer):
         with transaction.atomic():
             instance = super().update(instance, validated_data)
             try:
-                instance.clean_for_nomination()
+                if not self.partial:
+                    instance.clean_for_nomination()
                 instance.clean()
             except DjangoValidationError as e:
                 raise ValidationError(e.message_dict) from e

--- a/cypress/e2e/2.frontend/3.events/2.scan-pass.cy.js
+++ b/cypress/e2e/2.frontend/3.events/2.scan-pass.cy.js
@@ -10,9 +10,12 @@ describe("Check scan pass", () => {
     cy.contains("Stéllâr Sérènade Müsïc Fêstivàl");
     cy.contains("Accredited");
     cy.contains("Nominated");
+    cy.contains("Take photo");
+    // Can't print badge because participant isn't registered yet
+    cy.should("not.contain", "Print badge");
   });
   it("Check support staff view", () => {
-    cy.loginAdmin(false);
+    cy.loginSupport(false);
     cy.visit("/scan-pass?code=T6UQZRYW0S");
     cy.contains("Mr. Lyra-Pulse Solstice");
     cy.contains("lyra-pulse@example.com");
@@ -22,6 +25,8 @@ describe("Check scan pass", () => {
     cy.contains("Stéllâr Sérènade Müsïc Fêstivàl");
     cy.contains("Accredited");
     cy.contains("Registered");
+    cy.contains("Print badge");
+    cy.should("not.contain", "Take photo");
   });
   it("Check security staff view", () => {
     cy.loginSecurity(false);
@@ -32,8 +37,9 @@ describe("Check scan pass", () => {
     cy.should("not.contain", "Psychedelic Dreamscape Art Fair");
     cy.should("not.contain", "Quantum Quest: A Science Adventure Symposium");
     cy.should("not.contain", "Stéllâr Sérènade Müsïc Fêstivàl");
-    cy.should("not.contain", "Accredited");
-    cy.should("not.contain", "Nominated");
+    cy.should("not.contain", "Print badge");
+    cy.should("not.contain", "Take photo");
+    cy.get(".registrations-section").should("not.exist");
   });
   it("Scan wrong code", () => {
     cy.loginAdmin(false);

--- a/cypress/e2e/2.frontend/3.events/2.scan-pass.cy.js
+++ b/cypress/e2e/2.frontend/3.events/2.scan-pass.cy.js
@@ -77,6 +77,13 @@ describe("Check scan pass", () => {
       cy.contains("Register").click();
       cy.contains("Registration status updated.");
       cy.contains("Registered");
+
+      // Check taking a photo
+      cy.get('img[alt="contact photo"]').should("not.exist");
+      cy.contains("Take photo").click();
+      cy.contains("Capture").click();
+      cy.get('img[alt="contact photo"]').should("be.visible");
+
       cy.contains("Admin").click();
       cy.deleteContactGroup(group);
     });

--- a/src/components/ParticipantCard.vue
+++ b/src/components/ParticipantCard.vue
@@ -36,7 +36,7 @@
     </div>
     <div class="col-3 q-gutter-y-md">
       <slot name="buttons"></slot>
-      <q-img v-if="participant.hasPhoto" :src="photoUrl" alt="" />
+      <q-img v-if="participant.hasPhoto" :src="photoUrl" alt="contact photo" />
     </div>
   </div>
 </template>

--- a/src/pages/ScanPassPage.vue
+++ b/src/pages/ScanPassPage.vue
@@ -35,7 +35,7 @@
           <q-separator />
 
           <q-card-actions v-if="canViewRegistration || canEditContact">
-            <q-btn v-if="canViewRegistration" color="positive" icon="picture_as_pdf" :href="badgeUrl" target="_blank">
+            <q-btn v-if="canPrintBadge" color="positive" icon="picture_as_pdf" :href="badgeUrl" target="_blank">
               Print badge
             </q-btn>
             <q-btn v-if="canEditContact" color="primary" icon="photo_camera" @click="takePhotoRef?.show()">
@@ -43,7 +43,7 @@
             </q-btn>
           </q-card-actions>
         </q-card>
-        <div class="registrations-section q-pt-lg text-subtitle1 text-white">
+        <div class="registration-date-range q-pt-lg text-subtitle1 text-white">
           <q-card v-if="validRange" flat bordered class="valid-card bg-positive">Registered {{ validRange }}</q-card>
           <q-card v-else flat bordered class="valid-card bg-negative">Not registered</q-card>
         </div>
@@ -128,6 +128,12 @@ const canEditRegistration = computed(() => userStore.permissions.includes("event
 const registrations = computed(() =>
   [...(pass.value?.registrations ?? [])].sort((a, b) => (a.event.code > b.event.code ? 1 : -1)),
 );
+const canPrintBadge = computed(
+  () =>
+    userStore.permissions.includes("events.view_registration") &&
+    registrations.value.find((r) => r.status === "Registered"),
+);
+
 const validRange = computed(() => pass?.value?.validDateRange);
 
 const badgeUrl = computed(() => {
@@ -242,6 +248,7 @@ async function updateRegistrationStatus(registration: Registration, newStatus: R
   max-width: 125rem;
 }
 
+.registration-date-range,
 .registrations-section,
 .contact-section {
   flex-grow: 1;


### PR DESCRIPTION
https://helpdesk.eaudeweb.ro/issues/30917#note-10

- Hide print badge button if the contact is not yet registred to at least one event in the group 
- Add various tests to check when the action buttons need to appear and for what roles 