### PR TITLE
Add custom admin for audit log

### DIFF
--- a/contactdb/settings/settings.py
+++ b/contactdb/settings/settings.py
@@ -119,6 +119,7 @@ INSTALLED_APPS = [
     "health_check.db",
     "health_check.contrib.redis",
     "qr_code",
+    "rangefilter",
     # This app
     "api.apps.ApiConfig",
     "accounts.apps.AccountsConfig",

--- a/core/admin/__init__.py
+++ b/core/admin/__init__.py
@@ -4,6 +4,7 @@ from .country import *  # noqa: F403
 from .import_contact_photos_task import *  # noqa: F403
 from .import_focal_points_task import *  # noqa: F403
 from .import_legacy_contacts_tasks import *  # noqa: F403
+from .log_entry import *  # noqa: F403
 from .organization import *  # noqa: F403
 from .organization_type import *  # noqa: F403
 from .possible_duplicate import *  # noqa: F403

--- a/core/admin/log_entry.py
+++ b/core/admin/log_entry.py
@@ -1,0 +1,25 @@
+from admin_auto_filters.filters import AutocompleteFilterFactory
+from auditlog.admin import LogEntryAdmin
+from auditlog.filters import ResourceTypeFilter
+from auditlog.models import LogEntry
+from django.contrib import admin
+from django.contrib.admin import ShowFacets
+
+admin.site.unregister(LogEntry)
+
+
+@admin.register(LogEntry)
+class CustomLogEntryAdmin(LogEntryAdmin):
+    list_per_page = 20
+    show_facets = ShowFacets.NEVER
+
+    search_fields = [
+        "object_repr",
+        "object_id",
+    ]
+
+    list_filter = [
+        "action",
+        ResourceTypeFilter,
+        AutocompleteFilterFactory("user", "actor"),
+    ]

--- a/core/admin/log_entry.py
+++ b/core/admin/log_entry.py
@@ -13,15 +13,20 @@ admin.site.unregister(LogEntry)
 class CustomLogEntryAdmin(LogEntryAdmin):
     list_per_page = 20
     show_facets = ShowFacets.NEVER
-
     search_fields = [
         "object_repr",
         "object_id",
     ]
-
     list_filter = [
         "action",
         ResourceTypeFilter,
         AutocompleteFilterFactory("user", "actor"),
         ("timestamp", DateRangeFilterBuilder()),
+    ]
+    list_display = [
+        "created",
+        "resource_url",
+        "action",
+        "msg_short",
+        "user_url",
     ]

--- a/core/admin/log_entry.py
+++ b/core/admin/log_entry.py
@@ -4,6 +4,7 @@ from auditlog.filters import ResourceTypeFilter
 from auditlog.models import LogEntry
 from django.contrib import admin
 from django.contrib.admin import ShowFacets
+from rangefilter.filters import DateRangeFilterBuilder
 
 admin.site.unregister(LogEntry)
 
@@ -22,4 +23,5 @@ class CustomLogEntryAdmin(LogEntryAdmin):
         "action",
         ResourceTypeFilter,
         AutocompleteFilterFactory("user", "actor"),
+        ("timestamp", DateRangeFilterBuilder()),
     ]

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -321,7 +321,7 @@ Cypress.Commands.addAll({
     cy.fillInputs(filters);
     if (searchValue) {
       cy.get("#searchbar").type(searchValue);
-      cy.get("input[value=Search]").click();
+      cy.get("[role=search] input[value=Search]").click();
     }
   },
   triggerAction({ action, filters = {}, modelName, searchValue = "" }) {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "django==5.2.*",
     "django-admin-autocomplete-filter>=0.7.1",
     "django-admin-env-notice>=1.0.1",
+    "django-admin-rangefilter>=0.13.3",
     "django-auditlog>=3.1.2",
     "django-ckeditor>=6.7.2",
     "django-colorfield>=0.14.0",

--- a/uv.lock
+++ b/uv.lock
@@ -209,6 +209,7 @@ dependencies = [
     { name = "django" },
     { name = "django-admin-autocomplete-filter" },
     { name = "django-admin-env-notice" },
+    { name = "django-admin-rangefilter" },
     { name = "django-auditlog" },
     { name = "django-ckeditor" },
     { name = "django-colorfield" },
@@ -269,6 +270,7 @@ requires-dist = [
     { name = "django", specifier = "==5.2.*" },
     { name = "django-admin-autocomplete-filter", specifier = ">=0.7.1" },
     { name = "django-admin-env-notice", specifier = ">=1.0.1" },
+    { name = "django-admin-rangefilter", specifier = ">=0.13.3" },
     { name = "django-auditlog", specifier = ">=3.1.2" },
     { name = "django-ckeditor", specifier = ">=6.7.2" },
     { name = "django-colorfield", specifier = ">=0.14.0" },
@@ -486,6 +488,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/51/d9/38724a1196c2e42431ff3cb6d08ff2e790ff3d236d4065ccb59df141b419/django-admin-env-notice-1.0.1.tar.gz", hash = "sha256:1fc8da895b034f24a0c49d8170397aa8fd00db9eed63d3856cbbc2add6ed4d58", size = 4984, upload-time = "2024-10-19T12:10:04.624Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9f/ab/7cbc300a966ecd3b272448a50952340038294b938ff67a0fb3dacfecc68a/django_admin_env_notice-1.0.1-py2.py3-none-any.whl", hash = "sha256:353903ff22b6a483313b6f12fa94a77dca397861729ed1ba257e3ec0659ecb45", size = 5759, upload-time = "2024-10-19T12:10:03.286Z" },
+]
+
+[[package]]
+name = "django-admin-rangefilter"
+version = "0.13.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/bd/e05a9356f1ed15d1496ff901c33f9b9f354d154941d2366f961cd1530820/django_admin_rangefilter-0.13.3.tar.gz", hash = "sha256:8151b840753ea2c4de9963b1904cbbe7e786b7bc04de5dbd64567c86d287bbe8", size = 23588, upload-time = "2025-07-05T06:09:56.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/a5/fec346d1b793001c3a57947f643bfa174da667f0a8375ac59c8127243c8a/django_admin_rangefilter-0.13.3-py2.py3-none-any.whl", hash = "sha256:a776b1de5c5c153ed167e11fe757f138380207b2295a44d29d939c6ded76463a", size = 48396, upload-time = "2025-07-05T06:09:55.36Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
https://helpdesk.eaudeweb.ro/issues/31974 and https://helpdesk.eaudeweb.ro/issues/31479

- Only search object_repr and id 
- Add user filter and date range filter
- Remove Corellation ID filter a list display 

Changing the search to stop searching in the JSON objects should speed this up significantly 